### PR TITLE
Add link to SvelteKit quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo contains code for a SvelteKit static site generated using the [`create
 To create your own SvelteKit project, you can either
 
 - [Create your own repo from this template](https://github.com/render-examples/sveltekit-static/generate) and modify it for your needs
-- Create a new SvelteKit project by following the [SvelteKit Getting Started Guide](https://kit.svelte.dev/docs) and then making a few small modifications ([install `@sveltejs/adapter-static`](https://github.com/render-examples/sveltekit-static/commit/edee3add163fc00c76ac81be8c11cd9cb34ceb93), [configure `render.yaml`](https://github.com/render-examples/sveltekit-static/commit/87c806c95800847c059d03a466180800e8b843bc)) to deploy it to Render as a static site.
+- Create a new SvelteKit project by following the [SvelteKit Getting Started Guide](https://kit.svelte.dev/docs) and then making a few small modifications ([install `@sveltejs/adapter-static`](https://github.com/render-examples/sveltekit-static/commit/edee3add163fc00c76ac81be8c11cd9cb34ceb93), [configure `render.yaml`](https://github.com/render-examples/sveltekit-static/commit/87c806c95800847c059d03a466180800e8b843bc)) to deploy it to Render as a Static Site.
 
 ## Developing
 
@@ -26,6 +26,8 @@ npm run build
 
 > You can preview the built app with `npm run preview`. This should _not_ be used to serve your app in production.
 
-## Deployment
+## Deploying to Render
+
+Follow the deploy instructions at https://render.com/docs/deploy-sveltekit
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/sveltekit-static)


### PR DESCRIPTION
This adds a link to the SvelteKit quickstart guide to be consistent with https://github.com/render-examples/sveltekit.

It also capitalized "static site."