### PR TITLE
Fix render.yaml: "env" --> "runtime"

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - type: web
     name: sveltekit-static
-    env: static
+    runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: build
     autoDeploy: false


### PR DESCRIPTION
Per the [render.yaml schema](https://docs.render.com/blueprint-spec#runtime), `env` is still supported but is superseded by `runtime`. Using `env` will show a schema error if using the `render.yaml` validator in an IDE like VS Code.